### PR TITLE
Optimization/pathfinding

### DIFF
--- a/src/Area.cpp
+++ b/src/Area.cpp
@@ -301,10 +301,10 @@ void Area::Tick(Player* player)
             static_cast<float>(monsterPos.x),
             static_cast<float>(monsterPos.y));
         monster->Tick(player, this);
-        monsterPos = monster->GetPosition();
         collider->block(
             static_cast<float>(monsterPos.x),
-            static_cast<float>(monsterPos.y), true);
+            static_cast<float>(monsterPos.y),
+            true);
     }
 
     // Finally, we will unblock the positions of the monsters

--- a/src/Area.cpp
+++ b/src/Area.cpp
@@ -284,7 +284,7 @@ void Area::Tick(Player* player)
     std::vector<pdcpp::Point<int>> blockPositions = std::vector<pdcpp::Point<int>>();
     for (const auto& monster : livingMonsters)
     {
-        auto monsterPos = monster->GetPosition();
+        auto monsterPos = monster->GetTiledPosition();
         blockPositions.emplace_back(monsterPos);
         collider->block(
             static_cast<float>(monsterPos.x),
@@ -296,7 +296,7 @@ void Area::Tick(Player* player)
     for (const auto& monster : livingMonsters)
     {
         // We avoid the monsters from blocking itself by unblocking its position before ticking it.
-        auto monsterPos = monster->GetPosition();
+        auto monsterPos = monster->GetTiledPosition();
         collider->unblock(
             static_cast<float>(monsterPos.x),
             static_cast<float>(monsterPos.y));

--- a/src/Area.cpp
+++ b/src/Area.cpp
@@ -300,7 +300,18 @@ void Area::Tick(Player* player)
         collider->unblock(
             static_cast<float>(monsterPos.x),
             static_cast<float>(monsterPos.y));
+
+        // remove the monster position from the block positions because its position will change
+        auto it = std::ranges::find(blockPositions, monsterPos);
+        if (it != blockPositions.end())
+        {
+            blockPositions.erase(it);
+        }
+
+
         monster->Tick(player, this);
+        monsterPos = monster->GetTiledPosition();
+        blockPositions.emplace_back(monsterPos);
         collider->block(
             static_cast<float>(monsterPos.x),
             static_cast<float>(monsterPos.y),

--- a/src/Area.cpp
+++ b/src/Area.cpp
@@ -282,15 +282,18 @@ void Area::Tick(Player* player)
 
     // Then, we will mark the positions of the monsters as blocked in the collider
     std::vector<pdcpp::Point<int>> blockPositions = std::vector<pdcpp::Point<int>>();
-    for (const auto& monster : livingMonsters)
+    for (size_t i = 0; i < livingMonsters.size(); ++i)
     {
+        auto& monster = livingMonsters[i];
         auto monsterPos = monster->GetTiledPosition();
         blockPositions.emplace_back(monsterPos);
         collider->block(
             static_cast<float>(monsterPos.x),
             static_cast<float>(monsterPos.y),
             true);
+        monster->SetCanComputePath((i%staggerAmount) == pathfindingTickCounter); // stagger the pathfinding updates
     }
+    pathfindingTickCounter = (pathfindingTickCounter + 1) % staggerAmount;
 
     // Then, we will tick the monsters. So they can calculate paths and move
     for (const auto& monster : livingMonsters)

--- a/src/Area.cpp
+++ b/src/Area.cpp
@@ -279,31 +279,34 @@ void Area::LoadSpawnablePositions()
 void Area::Tick(Player* player)
 {
     SpawnCreature(); // we'll be spawning creatures as long as there's space for them and haven't reached the max count
+
     // Then, we will mark the positions of the monsters as blocked in the collider
     std::vector<pdcpp::Point<int>> blockPositions = std::vector<pdcpp::Point<int>>();
     for (const auto& monster : livingMonsters)
     {
-        blockPositions.emplace_back(monster->GetTiledPosition());
-    }
-    for (auto blockedPosition : blockPositions)
-    {
+        auto monsterPos = monster->GetPosition();
+        blockPositions.emplace_back(monsterPos);
         collider->block(
-            static_cast<float>(blockedPosition.x),
-            static_cast<float>(blockedPosition.y),
+            static_cast<float>(monsterPos.x),
+            static_cast<float>(monsterPos.y),
             true);
     }
+
     // Then, we will tick the monsters. So they can calculate paths and move
     for (const auto& monster : livingMonsters)
     {
         // We avoid the monsters from blocking itself by unblocking its position before ticking it.
+        auto monsterPos = monster->GetPosition();
         collider->unblock(
-            static_cast<float>(monster->GetTiledPosition().x),
-            static_cast<float>(monster->GetTiledPosition().y));
+            static_cast<float>(monsterPos.x),
+            static_cast<float>(monsterPos.y));
         monster->Tick(player, this);
+        monsterPos = monster->GetPosition();
         collider->block(
-            static_cast<float>(monster->GetTiledPosition().x),
-            static_cast<float>(monster->GetTiledPosition().y), true);
+            static_cast<float>(monsterPos.x),
+            static_cast<float>(monsterPos.y), true);
     }
+
     // Finally, we will unblock the positions of the monsters
     for (auto blockedPosition : blockPositions)
     {

--- a/src/Area.h
+++ b/src/Area.h
@@ -4,6 +4,7 @@
 #include "Inventory.h"
 #include "Dialogue.h"
 #include "AStarContainer.h"
+#include "Globals.h"
 #include "MapCollision.h"
 #include "pdcpp/core/Random.h"
 #include "pdcpp/graphics/ImageTable.h"
@@ -47,7 +48,7 @@ private:
     pdcpp::Random random = {};
     std::vector<pdcpp::Point<int>> spawnablePositions; // positions where monsters can spawn
     int pathfindingTickCounter; // Counter to stagger pathfinding updates
-    const int staggerAmount = 4; // Number of groups to stagger
+    const int staggerAmount = Globals::MONSTER_MAX_LIVING_COUNT; // Number of groups to stagger
 
 
 public:

--- a/src/Area.h
+++ b/src/Area.h
@@ -46,6 +46,9 @@ private:
     [[nodiscard]] Map_Layer ToMapLayer() const;
     pdcpp::Random random = {};
     std::vector<pdcpp::Point<int>> spawnablePositions; // positions where monsters can spawn
+    int pathfindingTickCounter; // Counter to stagger pathfinding updates
+    const int staggerAmount = 4; // Number of groups to stagger
+
 
 public:
     Area() = default;

--- a/src/Area.h
+++ b/src/Area.h
@@ -47,7 +47,7 @@ private:
     [[nodiscard]] Map_Layer ToMapLayer() const;
     pdcpp::Random random = {};
     std::vector<pdcpp::Point<int>> spawnablePositions; // positions where monsters can spawn
-    int pathfindingTickCounter; // Counter to stagger pathfinding updates
+    int pathfindingTickCounter = 0; // Counter to stagger pathfinding updates
     const int staggerAmount = Globals::MONSTER_MAX_LIVING_COUNT; // Number of groups to stagger
 
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -23,5 +23,6 @@ namespace  Globals
     constexpr int TICKS_BETWEEN_MONSTER_SPAWNS = 60; // Number of ticks between monster spawns
     constexpr int MONSTER_RANDOM_SPACING = 4; // Random spacing for monster when moving and finding a blocker
     constexpr int MAX_SPAWN_ATTEMPTS = 10; // Maximum number of attempts to spawn a monster
+    constexpr int PATH_FINDING_COOLDOWN = 30; // Cooldown for pathfinding in ticks
 }
 #endif //GLOBALS_H

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -9,20 +9,20 @@ namespace  Globals
 {
     // Constants for game settings
     constexpr int MAX_PATH_FIND_FAILURE_COUNT = 2; // Maximum number of pathfinding failures before resetting
-    constexpr int MULT_FOR_RESET_PATH_FIND_FAILURE = 10; // Count to reset pathfinding failure count
+    constexpr int MULT_FOR_RESET_PATH_FIND_FAILURE = 15; // Count to reset pathfinding failure count
     constexpr int MAP_TILE_SIZE = 16; // Size of each tile in the map
     constexpr int PLAYER_SIZE = 16; // Size of the player character
     constexpr int PLAYER_FOV_X = 234; // Field of view width for the player
     constexpr int PLAYER_FOV_Y = 136; // Field of view height for the player
     constexpr int MONSTER_AWARENESS_RADIUS = 50; // Radius within which monsters can detect the player
     constexpr int MONSTER_SPAWN_RADIUS = 20; // Radius within which monsters can spawn around the player
-    constexpr int MONSTER_ATTACK_RANGE = 1; // Range within which monsters can attack the player
+    constexpr int MONSTER_ATTACK_RANGE = 2; // Range within which monsters can attack the player
     constexpr float MONSTER_DIAGONAL_MOVE_SCALE = 0.7f; // Scale factor for diagonal movement speed of monsters
     constexpr int MONSTER_MAX_LIVING_COUNT = 10; // Maximum number of monsters that can be present in an area
     constexpr int MONSTER_TOTAL_TO_SPAWN = 50; // Total number of monsters to spawn in an area
     constexpr int TICKS_BETWEEN_MONSTER_SPAWNS = 60; // Number of ticks between monster spawns
     constexpr int MONSTER_RANDOM_SPACING = 4; // Random spacing for monster when moving and finding a blocker
     constexpr int MAX_SPAWN_ATTEMPTS = 10; // Maximum number of attempts to spawn a monster
-    constexpr int PATH_FINDING_COOLDOWN = 30; // Cooldown for pathfinding in ticks
+    constexpr int PATH_FINDING_COOLDOWN = 50; // Cooldown for pathfinding in ticks
 }
 #endif //GLOBALS_H

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -16,9 +16,14 @@ Monster::Monster(unsigned int _id, char* _name, char* _image, float _maxHp, int 
 void Monster::Tick(Player* player, Area* area)
 {
     pdcpp::Point<int> playerTiledPosition = player->GetTiledPosition();
-    if (!pathFound && pathFindFailureCount < Globals::MAX_PATH_FIND_FAILURE_COUNT && ShouldMove(playerTiledPosition))
+    if (pathFindingCooldown > 0)
+    {
+        pathFindingCooldown--;
+    }
+    else if (!pathFound && pathFindFailureCount < Globals::MAX_PATH_FIND_FAILURE_COUNT && ShouldMove(playerTiledPosition))
     {
         CalculateNodesToTarget(playerTiledPosition, area);
+        pathFindingCooldown = Globals::PATH_FINDING_COOLDOWN; // Reset cooldown after pathfinding
     }
     if (pathFound)
     {

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -20,7 +20,7 @@ void Monster::Tick(Player* player, Area* area)
     {
         pathFindingCooldown--;
     }
-    else if (!pathFound && pathFindFailureCount < Globals::MAX_PATH_FIND_FAILURE_COUNT && ShouldMove(playerTiledPosition))
+    else if (canComputePath && !pathFound && pathFindFailureCount < Globals::MAX_PATH_FIND_FAILURE_COUNT && ShouldMove(playerTiledPosition))
     {
         CalculateNodesToTarget(playerTiledPosition, area);
         pathFindingCooldown = Globals::PATH_FINDING_COOLDOWN; // Reset cooldown after pathfinding

--- a/src/Monster.h
+++ b/src/Monster.h
@@ -22,6 +22,7 @@ public:
 
     void Tick(Player* player, Area* area);
     std::shared_ptr<void> DecodeJson(char *buffer, jsmntok_t *tokens, int size) override;
+    void SetCanComputePath(bool value) { canComputePath = value; }
 
 private:
     [[nodiscard]] bool ShouldMove(pdcpp::Point<int> playerPosition) const;
@@ -34,6 +35,7 @@ private:
     pdcpp::Point<int> nextPosition = {0, 0}; // Next position to move to
     bool reachedNode = true; // Flag to check if the node was reached
     int pathFindingCooldown = 0; // Cooldown for pathfinding to avoid spamming
+    bool canComputePath = true; // Flag to check if pathfinding is allowed
 };
 
 

--- a/src/Monster.h
+++ b/src/Monster.h
@@ -33,6 +33,7 @@ private:
     int pathFindFailureCount = 0;
     pdcpp::Point<int> nextPosition = {0, 0}; // Next position to move to
     bool reachedNode = true; // Flag to check if the node was reached
+    int pathFindingCooldown = 0; // Cooldown for pathfinding to avoid spamming
 };
 
 


### PR DESCRIPTION
Optimizes pathfinding by throttling and staggering path calculations across monsters to reduce per-tick workload.

- Adds a per-monster cooldown and canComputePath flag to limit recalculations.
- Staggers pathfinding turns with pathfindingTickCounter and staggerAmount in Area.
- Introduces and adjusts configuration constants (PATH_FINDING_COOLDOWN, MONSTER_ATTACK_RANGE, etc.)